### PR TITLE
CS-39 Namespace item order

### DIFF
--- a/packages/builder-worker/src/utils.ts
+++ b/packages/builder-worker/src/utils.ts
@@ -43,7 +43,7 @@ export function stringifyReplacer(_: string, value: any) {
   } else if (value instanceof Set) {
     return {
       dataType: "Set",
-      value: [...value.entries()],
+      value: [...value],
     };
   } else {
     return value;


### PR DESCRIPTION
This addresses issue CS-39, for which the current bug blocking evaluation is due to the namespace objects' constituent parts are being serialized out of order, such the item declaration occurs after the namespace object declaration--as well as side effects related to the namespace imported object are also not serialized in the correct order.

The issue was that the individual namespace item declarations had no natural node to congeal around during the editor assignment. the namespace import region of the consuming module was a direct consumer of the namespace item declarations. Our rules are that a region can merge into their consumers' editors only if all the consumers of a region are in the same module. The fix is to manufacture a virtual region node that represents a "namespace marker" within the imported namespace module, which in turn consumes all the declarations that make up the namespace object. By doing this, the namespace marker acts as an accretion point that all the namespace item declarations will be drawn to during editor assignment because the namespace marker node which consumes all the item declarations is in the same module as the namespace items. During editor assignment, we'll just skip over this namespace marker node--as it is only a grouping mechanism. The actual namespace import region in the consuming module is the region that is actually turned into a namespace object (which is as-designed) 