### PR TITLE
Workaround for babel bug not recognizing assignment expression's left-hand side as a binding reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@
 /packages/shared/**/*.js.map
 
 !webpack.config.js
+!/bundles/**/dist

--- a/packages/test-app/babel-eval.js
+++ b/packages/test-app/babel-eval.js
@@ -1,4 +1,4 @@
-import { parseSync } from "https://local-disk/bundles/@babel/core/7.9.0/mjrA8i7qhVIlMPwC63GVqBhU0eQ=/src/index.js";
+import { parseSync } from "https://local-disk/bundles/@babel/core/7.9.0/a0SOPjfzJAVu1+wkWuszrTrDPDw=/src/index.js";
 import flatMap from "https://local-disk/bundles/lodash/4.17.19/NbTWX71F-LVzbYPD1xMbcjuRjD0=/flatMap.js";
 
 // TODO test a bundle built from CJS sources as well


### PR DESCRIPTION
This is a workaround for the babel bug https://github.com/babel/babel/issues/10299 where it does not recognize the left-hand side of an assignment expression as a binding reference. The workaround is to gather all the assignment expressions, and loop through them looking for module-scoped assignment expressions. And for the module-scoped expressions that we find, to create code regions for them as well as reference pointers in their respective declaration regions.