### PR TITLE
Fixes CS-91: CJS not evaluating correctly

### DIFF
--- a/packages/builder-node/src/nodes/cjs-interop.ts
+++ b/packages/builder-node/src/nodes/cjs-interop.ts
@@ -407,7 +407,7 @@ class ESModuleShimNode implements BuilderNode {
       );
       if (nonDefaultExports.length > 0) {
         exports.push(
-          `const { ${nonDefaultExports.join(", ")} } = implementation();`
+          `const { ${nonDefaultExports.join(", ")} } = implementation;`
         );
         exports.push(`export { ${nonDefaultExports.join(", ")} };`);
       }
@@ -418,7 +418,7 @@ class ESModuleShimNode implements BuilderNode {
 ${exports.join("\n")}`;
     } else {
       src = `import implementation from "./${basename}$cjs$";
-export default implementation();`;
+export default implementation;`;
     }
     return {
       node: new AllNode([

--- a/packages/builder-node/test/install-test.ts
+++ b/packages/builder-node/test/install-test.ts
@@ -494,7 +494,7 @@ module.exports = {
         src,
         `
         import implementation from "./index.js$cjs$";
-        export default implementation();
+        export default implementation;
         `
       );
       src = await (
@@ -504,7 +504,7 @@ module.exports = {
         src,
         `
         import implementation from "./a.js$cjs$";
-        export default implementation();
+        export default implementation;
         `
       );
     });


### PR DESCRIPTION
don't eval CJS shim implementation in wrapper code--rather the CJS shim should eval at the point of consumption