### PR TITLE
CS-117 inter-module editor order

### DIFF
--- a/packages/builder-worker/src/region-walker.ts
+++ b/packages/builder-worker/src/region-walker.ts
@@ -614,7 +614,18 @@ class EditorAssigner {
           r.declaration.declaratorOfRegion === pointer
       )
     );
-    if (consumers.every((c) => c.moduleHref === moduleHref)) {
+    // we only merge into consumers that are in our module and all share the
+    // same editor, unless we have declarators--in that case all our consumers
+    // need us to merge into them regardless
+    if (
+      consumers.every(
+        (c) =>
+          c.moduleHref === moduleHref &&
+          [...c.assignment.editors][0] ===
+            [...consumers[0].assignment.editors][0]
+      ) ||
+      hasDeclarators
+    ) {
       let namespaceMarkerConsumer = consumers.find((c) =>
         c.assignment.editors.has(regionId(moduleHref, NamespaceMarker))
       );

--- a/packages/builder-worker/test/describe-file-test.ts
+++ b/packages/builder-worker/test/describe-file-test.ts
@@ -668,6 +668,39 @@ QUnit.module("describe-file", function () {
     );
   });
 
+  test("a code region declaration can have a reference as the left-hand side of an assignment expression that is a member expression", async function (assert) {
+    let { desc, editor } = describeESModule(`
+      let a = {};
+      let b = 'bar';
+      function initA() {
+        a[b] = 'foo';
+      }
+      export {};
+    `);
+    keepAll(desc, editor);
+    let { declaration: a } = desc.declarations.get("a")!;
+    assert.equal(a.references.length, 2);
+    let { declaration: b } = desc.declarations.get("b")!;
+    assert.equal(b.references.length, 2);
+    for (let reference of a.references) {
+      editor.replace(reference, "alpha");
+    }
+    for (let reference of b.references) {
+      editor.replace(reference, "bravo");
+    }
+    assert.codeEqual(
+      editor.serialize().code,
+      `
+      let alpha = {};
+      let bravo = 'bar';
+      function initA() {
+        alpha[bravo] = 'foo';
+      }
+      export {};
+      `
+    );
+  });
+
   test("a code region declaration will not have a reference to a similarly named left-hand side of an assignment expression when the referenced binding is not in the module scope", async function (assert) {
     let { desc, editor } = describeESModule(`
       let a;

--- a/packages/test-app/babel-eval.js
+++ b/packages/test-app/babel-eval.js
@@ -1,4 +1,4 @@
-import { parseSync } from "https://local-disk/bundles/@babel/core/7.9.0/mjrA8i7qhVIlMPwC63GVqBhU0eQ=/src/index.js";
+import { parseSync } from "https://local-disk/bundles/@babel/core/7.9.0/d8b7Ummfqw3exmsT8yWq3gr13OM=/src/index.js";
 import flatMap from "https://local-disk/bundles/lodash/4.17.19/NbTWX71F-LVzbYPD1xMbcjuRjD0=/flatMap.js";
 
 // TODO test a bundle built from CJS sources as well


### PR DESCRIPTION
maintain inter-module region dependency order for editors when regions from within a module are splatted across a bundle