### PR TITLE
Fixing ordering issue related to declarations with side effects

### DIFF
--- a/packages/builder-worker/src/describe-file.ts
+++ b/packages/builder-worker/src/describe-file.ts
@@ -404,7 +404,6 @@ export function describeFile(ast: File, filename: string): FileDescription {
         }
       }
       if (sideEffects) {
-        desc.regions[sideEffects].dependsOn.add(declarationPointer);
         desc.regions[documentPointer].dependsOn.add(declarationPointer);
       }
       dependsOn.set(builder.regions[declarationPointer], consumes);

--- a/packages/builder-worker/test/builder-test.ts
+++ b/packages/builder-worker/test/builder-test.ts
@@ -1767,8 +1767,8 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
-        let unused_a = initCache();
         console.log(i());
+        let unused_a = initCache();
         export {};
         `
       );
@@ -1799,6 +1799,7 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
+        console.log(i());
         function getNative(a, b) { return a[b]; }
         var defineProperty = function () {
           try {
@@ -1807,7 +1808,6 @@ QUnit.module("module builder", function (origHooks) {
             return func;
           } catch (e) {}
         }();
-        console.log(i());
         export {};
         `
       );
@@ -1840,6 +1840,7 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
+        console.log(i());
         class Cache {
           constructor(opts) {
             window.__cache = { bar: opts};
@@ -1847,7 +1848,6 @@ QUnit.module("module builder", function (origHooks) {
         }
         let b = 'foo';
         let unused_a = new Cache(b);
-        console.log(i());
         export {};
         `
       );
@@ -6900,8 +6900,8 @@ QUnit.module("module builder", function (origHooks) {
           source,
           `
           const puppies = ["mango", "van gogh"];
-          function myPuppies() { return puppies; }
           function getPuppies() { return puppies; }
+          function myPuppies() { return puppies; }
           function cutestPuppies() { return puppies; }
 
           let jojo = 'Jojo';

--- a/packages/recipes/recipes/@babel/core.json
+++ b/packages/recipes/recipes/@babel/core.json
@@ -22,7 +22,8 @@
         "inherits": "https://catalogjs.com/pkgs/@catalogjs/polyfills/0.0.1/inherits.js"
       },
       "macros": {
-        "process\\.env\\.NODE_ENV": "'production'"
+        "process\\.env\\.NODE_ENV": "'production'",
+        "import \\* as context from \"../index\";": "const context = {}; // catalogjs: consider using dynamic import of \"../index\" instead so we don't form a static binding dependency cycle"
       },
       "dependencies": {
         "@catalogjs/polyfills": "^0.0.1"

--- a/packages/recipes/recipes/@babel/core.json
+++ b/packages/recipes/recipes/@babel/core.json
@@ -23,7 +23,7 @@
       },
       "macros": {
         "process\\.env\\.NODE_ENV": "'production'",
-        "import \\* as context from \"../index\";": "const context = {}; // catalogjs: consider using dynamic import of \"../index\" instead so we don't form a static binding dependency cycle"
+        "import \\* as context from \"../index\";": "const context = {}; // catalogjs: consider using dynamic import of \"../index\" instead so we don't form a static binding dependency cycle, which is what I think it wants to be since this is consumed inside of a generator function"
       },
       "dependencies": {
         "@catalogjs/polyfills": "^0.0.1"


### PR DESCRIPTION
 fixed a silly bug that was dropping our region dependencies in certain scenarios, resulting in declarations with side effects to not be serialized before the bindings the region consumes. Also added a bandaid to break static binding dependency cycle that exists in babel (which is probably a pretty rare and dubious scenario). Ultimately we'll need to deal with it, but probably not right now https://linear.app/cardstack/issue/CS-121/support-for-binding-dependency-cycle