### PR TITLE
Fixes CS-123: binding rename bug plus better side effect traversal

### DIFF
--- a/packages/builder-worker/src/module-rewriter.ts
+++ b/packages/builder-worker/src/module-rewriter.ts
@@ -317,8 +317,7 @@ export class ModuleRewriter {
       return;
     }
 
-    for (let pointer of this.editor.includedRegions()) {
-      let region = this.module.desc.regions[pointer];
+    for (let region of this.module.desc.regions) {
       if (region.type !== "declaration") {
         continue;
       }
@@ -373,7 +372,13 @@ export class ModuleRewriter {
             localName
           );
           if (
-            source.type === "resolved" &&
+            (source.type === "resolved" ||
+              (this.ownAssignments.find(
+                (a) =>
+                  a.module.url.href ===
+                  (source as UnresolvedResult).importedFromModule.url.href
+              ) &&
+                isNamespaceMarker(source.importedAs))) &&
             outerResolution?.type === "declaration"
           ) {
             setDoubleNestedMapping(

--- a/packages/builder-worker/test/builder-test.ts
+++ b/packages/builder-worker/test/builder-test.ts
@@ -1767,8 +1767,8 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
-        console.log(i());
         let unused_a = initCache();
+        console.log(i());
         export {};
         `
       );
@@ -1799,7 +1799,6 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
-        console.log(i());
         function getNative(a, b) { return a[b]; }
         var defineProperty = function () {
           try {
@@ -1808,6 +1807,7 @@ QUnit.module("module builder", function (origHooks) {
             return func;
           } catch (e) {}
         }();
+        console.log(i());
         export {};
         `
       );
@@ -1840,7 +1840,6 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
-        console.log(i());
         class Cache {
           constructor(opts) {
             window.__cache = { bar: opts};
@@ -1848,6 +1847,7 @@ QUnit.module("module builder", function (origHooks) {
         }
         let b = 'foo';
         let unused_a = new Cache(b);
+        console.log(i());
         export {};
         `
       );


### PR DESCRIPTION
This fixes 3 issues that were part of CS-123:
- fixes bug where binding reference was not being renamed when it was placed in a separate region editor than its declaration
- fixes side effect ordering issue, I've reworked the side effect traversal such that we walk the side effects immediately before the first time we walk thru a region in a different module then we were in before we took our "step" in the walk. (previously we just buzzed all the side effects of modules that were in the bundle without being cognizant of how we were walking thru the regions in the bundle
- this fix exposed a new bug when building lodash, were external reexports were being classified as our own named exports.