### PR TITLE
CS-125 Fixing issue around reference pointer resolutions

### DIFF
--- a/packages/builder-worker/src/resolver.ts
+++ b/packages/builder-worker/src/resolver.ts
@@ -5,6 +5,7 @@ import { LockEntries } from "./nodes/lock-file";
 import { makeURLEndInDir } from "./path";
 
 export const catalogjsHref = "https://catalogjs.com/pkgs/";
+export const localDiskHref = "https://local-disk/pkgs/";
 export const workingHref = "https://working/";
 
 export interface Resolver {
@@ -164,6 +165,7 @@ export function pkgInfoFromCatalogJsURL(
 ): Required<PkgInfo> | undefined {
   if (
     !url.href.startsWith(catalogjsHref) &&
+    !url.href.startsWith(localDiskHref) &&
     !url.href.startsWith(workingHref)
   ) {
     return;
@@ -173,7 +175,10 @@ export function pkgInfoFromCatalogJsURL(
   let version: string;
   let hash: string;
   let modulePath: string | undefined;
-  let path = url.href.replace(catalogjsHref, "").replace(workingHref, "");
+  let path = url.href
+    .replace(catalogjsHref, "")
+    .replace(workingHref, "")
+    .replace(localDiskHref, "");
   let parts = path.split("/");
   let registryOrScopedName = parts.shift()!;
   let registry: string;

--- a/packages/test-app/babel-eval.js
+++ b/packages/test-app/babel-eval.js
@@ -1,5 +1,5 @@
-import { parseSync } from "https://local-disk/bundles/@babel/core/7.9.0/mjrA8i7qhVIlMPwC63GVqBhU0eQ=/src/index.js";
-import flatMap from "https://local-disk/bundles/lodash/4.17.19/NbTWX71F-LVzbYPD1xMbcjuRjD0=/flatMap.js";
+import { parseSync } from "https://local-disk/pkgs/npm/@babel/core/7.9.0/mjrA8i7qhVIlMPwC63GVqBhU0eQ=/src/index.js";
+import flatMap from "https://local-disk/pkgs/npm/lodash/4.17.19/NbTWX71F-LVzbYPD1xMbcjuRjD0=/flatMap.js";
 
 // TODO test a bundle built from CJS sources as well
 

--- a/packages/test-app/package.json
+++ b/packages/test-app/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start-pkg": "node ../file-daemon/dist/main.js . ../test-lib ../recipes ../../bundles",
-    "start": "node ../file-daemon/bin/file-daemon . ../test-lib ../recipes ../../bundles"
+    "start-pkg": "node ../file-daemon/dist/main.js . ../test-lib ../recipes ../../pkgs",
+    "start": "node ../file-daemon/bin/file-daemon . ../test-lib ../recipes ../../pkgs"
   }
 }

--- a/packages/test-lib/package.json
+++ b/packages/test-lib/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start-pkg": "node ../file-daemon/dist/main.js . ../recipes ../../bundles",
-    "start": "node ../file-daemon/bin/file-daemon . ../recipes ../../bundles"
+    "start-pkg": "node ../file-daemon/dist/main.js . ../recipes ../../pkgs",
+    "start": "node ../file-daemon/bin/file-daemon . ../recipes ../../pkgs"
   }
 }


### PR DESCRIPTION
This fixes CS-125, which is an issue around resolving reference pointers: we were not consistently using the original name for a binding when looking up the binding's resolution which resulted in colliding declarations that happen to coincidently have the original name as a binding we were looking up (which ultimately resulted in using the wrong reference pointers)