### PR TITLE
CS-128: fixes issue with side effect concatenation and better determination of side effect sub-graph roots

### DIFF
--- a/packages/builder-worker/src/code-region.ts
+++ b/packages/builder-worker/src/code-region.ts
@@ -314,11 +314,10 @@ export class RegionBuilder {
         );
       }
       if (pathOrPaths.find((p) => pathOrPaths[0].type !== p.type)) {
-        throw new Error(
-          `cannot create code region for multiple paths that have different types`
-        );
+        nodeType = "multipleTypes";
+      } else {
+        nodeType = pathOrPaths[0].type;
       }
-      nodeType = pathOrPaths[0].type;
     } else {
       nodeType = pathOrPaths.type;
     }


### PR DESCRIPTION
fixed bug with side effect concatenation, and refined the pruning of side-effectful declarations that are ultimately traversable from root of side-effect subgraph for a module by actually walking the dependency graph