### PR TITLE
CS-130 fix for cyclic module side effect loading

### DIFF
--- a/packages/builder-worker/test/builder-test.ts
+++ b/packages/builder-worker/test/builder-test.ts
@@ -1767,8 +1767,8 @@ QUnit.module("module builder", function (origHooks) {
         await bundleCode(assert.fs),
         `
         function i() { return 1; }
-        let unused_a = initCache();
         console.log(i());
+        let unused_a = initCache();
         export {};
         `
       );


### PR DESCRIPTION
This issue comes down to loading side effects for cyclic modules. our logic was failing to establish dependencies between regions when we tried to load side effects in a module for which we were in the midsts of loading side effects. I addressed this by maintaining a "side effect stack", and if we were in the middle of trying to load side effects for a module and followed a path that eventually wrapped back into the same module, we would not try to load side effects again for that module we wrapped back into, and let the original attempt complete.