### PR TITLE
CS-132 breaking ties in dependency resolution with the module that is the deepest dep in the bundle

### DIFF
--- a/packages/builder-worker/src/nodes/combine-modules.ts
+++ b/packages/builder-worker/src/nodes/combine-modules.ts
@@ -62,6 +62,7 @@ export class CombineModulesNode implements BuilderNode {
     let depResolver = new DependencyResolver(
       this.dependencies,
       assignments,
+      resolutionsInDepOrder,
       this.lockEntries,
       lockFile,
       resolutionRecipes,


### PR DESCRIPTION
Previously tie breaks for identical dependency resolutions were broken alphabetically because I thought that the bundle you chose didn't really matter so long as it was a deterministic decision. This was not right. The issue is that you still need to load all the side effects of the bundle that you choose. If you chose a bundle that actually consumes the module you are currently in, that means that a cycle could be formed in your side effects. So when breaking ties, we'll always choose the resolution that is contained in the bundle that is the deepest dependency in the resulting bundle so that we eliminate the rist of forming cycles in our side effects unnecessarily.