### PR TITLE
CS-156 added support for side effectful declaration initialization

### DIFF
--- a/packages/builder-worker/src/code-region.ts
+++ b/packages/builder-worker/src/code-region.ts
@@ -64,6 +64,7 @@ export interface LocalDeclarationDescription
   type: "local";
   declaratorOfRegion: RegionPointer | undefined;
   source: string;
+  initializedBy: RegionPointer[];
   original?: {
     bundleHref: string;
     range: string;

--- a/packages/builder-worker/src/dependency-resolution.ts
+++ b/packages/builder-worker/src/dependency-resolution.ts
@@ -93,6 +93,7 @@ export class DependencyResolver {
   >;
   // consumingModuleHref => importedFromModuleHref => importedName => ResolvedResult | UnresolvedResult
   private declarationResolutionCache: DeclarationResolutionCache = new Map();
+  private ownAssignments: BundleAssignment[];
   constructor(
     dependencies: Dependencies,
     assignments: BundleAssignment[],
@@ -106,6 +107,9 @@ export class DependencyResolver {
       | undefined,
     private bundle: URL
   ) {
+    this.ownAssignments = assignments.filter(
+      (a) => a.bundleURL.href === bundle.href
+    );
     this.consumedDeps = gatherDependencies(
       dependencies,
       assignments,
@@ -122,14 +126,13 @@ export class DependencyResolver {
     importedName: string | NamespaceMarker,
     importedFromModule: Resolution,
     consumingModule: Resolution,
-    ownAssignments: BundleAssignment[],
     importedPointer?: RegionPointer // if you have this handy it saves work passing it in--otherwise we'll calculate it
   ): ResolvedResult | UnresolvedResult {
     return resolveDeclaration(
       importedName,
       importedFromModule,
       consumingModule,
-      ownAssignments,
+      this.ownAssignments,
       this.declarationResolutionCache,
       this,
       importedPointer

--- a/packages/builder-worker/src/description-encoder.ts
+++ b/packages/builder-worker/src/description-encoder.ts
@@ -90,6 +90,7 @@ const declarationLegend = [
   "importIndex", // number | null
   "importedName", // string | { n: true }
   "declaratorOfRegion", // number | null
+  "initializedBy", // [number]
   "source", // string | null
 ];
 
@@ -342,6 +343,7 @@ function decodeModuleDescription(encoded: string): ModuleDescription {
         );
     }
   }
+
   assignCodeRegionPositions(regions);
 
   return {

--- a/packages/builder-worker/src/nodes/bundle.ts
+++ b/packages/builder-worker/src/nodes/bundle.ts
@@ -16,6 +16,7 @@ import {
   HTMLEntrypoint,
   Dependencies,
 } from "./entrypoint";
+import { setIntersection as intersection } from "../utils";
 import { makeURLEndInDir } from "../path";
 import { Resolver } from "../resolver";
 import { LockEntries } from "./lock-file";
@@ -301,7 +302,7 @@ export class Assigner {
     // we need to be our own bundle
     let bundleURL = this.internalBundleURL();
     let enclosingBundles = intersection(
-      consumers.map((c) => c.internalAssignment.enclosingBundles)
+      ...consumers.map((c) => c.internalAssignment.enclosingBundles)
     );
     enclosingBundles.add(bundleURL.href); // we are also enclosed by our own bundle
     let internalAssignment = {
@@ -482,17 +483,6 @@ function setConsumersOf(
     consumersOf.set(consumed.href, new Set());
   }
   consumersOf.get(consumed.href)!.add({ isDynamic, module: consumer });
-}
-
-function intersection<T>(sets: Set<T>[]): Set<T> {
-  let output: Set<T> = new Set();
-  let [first, ...rest] = sets;
-  for (let element of first) {
-    if (rest.every((s) => s.has(element))) {
-      output.add(element);
-    }
-  }
-  return output;
 }
 
 export interface TestingOptions {

--- a/packages/builder-worker/src/nodes/combine-modules.ts
+++ b/packages/builder-worker/src/nodes/combine-modules.ts
@@ -202,8 +202,7 @@ function exposedRegions(
       let source = depResolver.resolveDeclaration(
         original,
         importedFrom,
-        sourceModule,
-        ownAssignments
+        sourceModule
       );
       if (source.type === "resolved") {
         let exposedInfo = {

--- a/packages/builder-worker/src/utils.ts
+++ b/packages/builder-worker/src/utils.ts
@@ -59,3 +59,24 @@ export function rangeIntersection(...ranges: string[]): string {
   }
   return intersect(...cleansedRanges);
 }
+
+export function setIntersection<T>(...sets: Set<T>[]): Set<T> {
+  let output: Set<T> = new Set();
+  let [first, ...rest] = sets;
+  for (let element of first) {
+    if (rest.every((s) => s.has(element))) {
+      output.add(element);
+    }
+  }
+  return output;
+}
+
+export function hasIntersection<T>(...sets: Set<T>[]): Boolean {
+  let [first, ...rest] = sets;
+  for (let element of first) {
+    if (rest.every((s) => s.has(element))) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
CS-156 added support to ensure that side effectful initializers for a declaration are always executed before they are consumed outside of their module.

The approach I'm taking is that during the analyze module state (where we initially parse the module and determine the code regions), we'll make note of any side effects that consume bindings that we declared locally in the module. These are the possible side-effect initializers for the bindings. These "initializer" regions will then be noted in the module description within the declaration region that they potentially initialize. Note that an imported binding may also be initialized in such a way (albeit it's a bit awkward), but it will be necessary for the consuming module to import the module that has the side-effectful initializer if that is what is desired.

This new "initializer" property travels with the declaration region as the declaration moves from bundle to bundle, and the property is updated accordingly to correctly reflect the initializer region in the current bundle.

When we are walking the modules that will comprise a new bundle, if we encounter a declaration with an "initializer" property, immediately after walking all the regions that make up the subgraph of the declaration, we will then walk the subgraph that makes up the initializer regions. After we finish that walk, we'll manufacture a virtual DeclarationConsumer region whose dependencies are our initializer regions (and their subgraph). This virtual region acts merely as a grouping mechanism for our tree traversal, and RegionEditor assignment--it's not actually serialized into the bundle. Any subsequent regions that we walk through that consume our declaration will be given the virtual DeclarationConsumer region in lieu of the actual declaration region. In this manner the consumers of our declaration will have a dependency on a subgraph that includes the initializer regions (a subgraph the ultimately includes our declaration region). In this manner, when we invert our tree of regions that we have visited and form the region editors from that inverted tree, the ordering of the initializers and the consumers of our deps will be correct since the consumers will have direct dependencies (via our virtual nodes) on the side effect initializer regions.