### PR TITLE
CS-188 add code region for reexport specifiers

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -43,6 +43,15 @@
     {
       "type": "node",
       "request": "launch",
+      "name": "Run control-test",
+      "cwd": "${workspaceRoot}/packages/builder-node",
+      "env": {},
+      "program": "${workspaceRoot}/packages/builder-node/bin/control-test.js",
+      "args": []
+    },
+    {
+      "type": "node",
+      "request": "launch",
       "name": "Run node build",
       "cwd": "${workspaceRoot}",
       "env": {},

--- a/packages/builder-node/bin/control-test.ts
+++ b/packages/builder-node/bin/control-test.ts
@@ -1,0 +1,5 @@
+#! node
+
+//@ts-ignore not actually redefining block-scoped var
+const esmRequire = require("esm")(module, { cjs: true });
+esmRequire("../src/control-test");

--- a/packages/builder-node/src/control-test.ts
+++ b/packages/builder-node/src/control-test.ts
@@ -1,0 +1,43 @@
+import { parseSync } from "@babel/core";
+import {
+  ExportNamedDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+} from "@babel/types";
+import flatMap from "lodash/flatMap";
+
+const code = `
+  import { bar, bloop } from "foo";
+
+  const vanGogh = "Van Gogh";
+  const mango = "Mango";
+  function cutestPuppies() {
+    return [ vanGogh, mango, bar, bloop ];
+  }
+
+  export { vanGogh, mango, cutestPuppies };
+`;
+let file = parseSync(code, { configFile: false });
+if (file?.type === "File") {
+  let body = file.program.body;
+  let importDeclarations = body.filter(
+    (s) => s.type === "ImportDeclaration"
+  ) as ImportDeclaration[];
+  let exportNamedDeclarations = body.filter(
+    (s) => s.type === "ExportNamedDeclaration"
+  ) as ExportNamedDeclaration[];
+  let namedImports = flatMap(importDeclarations, (d) =>
+    (d.specifiers.filter(
+      (s) => s.type === "ImportSpecifier"
+    ) as ImportSpecifier[]).map((s) => s.imported.name)
+  );
+  let namedExports = flatMap(exportNamedDeclarations, (d) =>
+    (d.specifiers.filter(
+      (s) => s.type === "ExportSpecifier"
+    ) as ExportSpecifier[]).map((s) => s.exported.name)
+  );
+
+  console.log(`Named imports are: ${namedImports.join()}`);
+  console.log(`Named exports are: ${namedExports.join()}`);
+}

--- a/packages/builder-worker/src/code-region.ts
+++ b/packages/builder-worker/src/code-region.ts
@@ -24,6 +24,7 @@ export type CodeRegion =
   | DocumentCodeRegion
   | GeneralCodeRegion
   | ImportCodeRegion
+  | ReexportSpecifierCodeRegion
   | DeclarationCodeRegion
   | ReferenceCodeRegion;
 
@@ -141,6 +142,19 @@ export function isImportCodeRegion(region: any): region is ImportCodeRegion {
   );
 }
 
+export interface ReexportSpecifierCodeRegion extends BaseCodeRegion {
+  type: "reexport-specifier";
+}
+export function isReexportSpecifierCodeRegion(
+  region: any
+): region is ReexportSpecifierCodeRegion {
+  return (
+    typeof region === "object" &&
+    "type" in region &&
+    region.type === "reexport-specifier"
+  );
+}
+
 // When a reference region is inserted, or another region is inserted around a
 // reference region, then the parent of the reference region will automatically
 // depend on the reference region.
@@ -174,7 +188,8 @@ export function isCodeRegion(region: any): region is CodeRegion {
     isGeneralCodeRegion(region) ||
     isDeclarationCodeRegion(region) ||
     isReferenceCodeRegion(region) ||
-    isImportCodeRegion(region)
+    isImportCodeRegion(region) ||
+    isReexportSpecifierCodeRegion(region)
   );
 }
 

--- a/packages/builder-worker/src/dependency-resolution.ts
+++ b/packages/builder-worker/src/dependency-resolution.ts
@@ -692,7 +692,7 @@ function resolveDeclaration(
     if (pkgURL) {
       let resolution = depResolver.resolutionByConsumptionRegion(
         sourceModule,
-        exportDesc.exportRegion,
+        exportDesc.reexportSpecifierRegion,
         pkgURL
       );
       assertDeclarationResolution(
@@ -1005,7 +1005,7 @@ function gatherDependencies(
               },
               bundleHref,
               consumedBy: module,
-              consumedByPointer: exportDesc.exportRegion,
+              consumedByPointer: exportDesc.reexportSpecifierRegion,
               name: NamespaceMarker,
               source: pkgModule.url.href,
               range: dependency.range,
@@ -1068,7 +1068,7 @@ function gatherDependencies(
               },
               bundleHref,
               consumedBy: module,
-              consumedByPointer: exportDesc.exportRegion,
+              consumedByPointer: exportDesc.reexportSpecifierRegion,
               name: resolutionBindingName(exportDesc.name, source.module),
               source: source.declaration.source,
               range: dependency.range,

--- a/packages/builder-worker/src/description-encoder.ts
+++ b/packages/builder-worker/src/description-encoder.ts
@@ -20,9 +20,11 @@ import isEqual from "lodash/isEqual";
 import invert from "lodash/invert";
 import {
   DeclarationCodeRegion,
+  DocumentCodeRegion,
   GeneralCodeRegion,
   ImportCodeRegion,
   NamespaceMarker,
+  ReexportSpecifierCodeRegion,
   ReferenceCodeRegion,
 } from "./code-region";
 import { assignCodeRegionPositions } from "./region-editor";
@@ -40,6 +42,7 @@ const regionTypeShorthand = {
   import: "i",
   declaration: "d",
   document: "o",
+  "reexport-specifier": "s",
 };
 
 // TODO need to make a shorthand for URLs, all of our URLs start with https://catalogjs.com/pkgs/
@@ -82,6 +85,8 @@ const referenceCodeRegionLegend = [
 
 const documentCodeRegionLegend = [...baseCodeRegionLegend];
 
+const reexportSpecifierCodeRegionLegend = [...baseCodeRegionLegend];
+
 const declarationLegend = [
   "type", // "l" = local, "i" = import
   "declaredName", // string,
@@ -107,6 +112,7 @@ const exportDescLegend = [
   "name", // string | { n: true }
   "exportRegion", // number
   "importIndex", // number | null
+  "reexportSpecifierRegion", // number | null
 ];
 
 interface Pojo {
@@ -185,6 +191,10 @@ function encodeModuleDescription(desc: ModuleDescription): string {
                 });
               case "document":
                 return encodeObj(r, documentCodeRegionLegend, {
+                  type: { ...regionTypeShorthand },
+                });
+              case "reexport-specifier":
+                return encodeObj(r, reexportSpecifierCodeRegionLegend, {
                   type: { ...regionTypeShorthand },
                 });
               case "import":
@@ -297,7 +307,16 @@ function decodeModuleDescription(encoded: string): ModuleDescription {
                   type: { ...regionTypeShorthand },
                 },
                 { dependsOn: "Set" }
-              ) as ReferenceCodeRegion;
+              ) as DocumentCodeRegion;
+            case "reexport-specifier":
+              return decodeArray(
+                v,
+                reexportSpecifierCodeRegionLegend,
+                {
+                  type: { ...regionTypeShorthand },
+                },
+                { dependsOn: "Set" }
+              ) as ReexportSpecifierCodeRegion;
             case "import":
               return decodeArray(
                 v,

--- a/packages/builder-worker/src/region-editor.ts
+++ b/packages/builder-worker/src/region-editor.ts
@@ -548,7 +548,8 @@ export class RegionEditor {
     if (
       siblingDispositions.length > 0 &&
       parentRegion.type !== "document" &&
-      (parentRegion.type === "reference" || !parentRegion.preserveGaps) &&
+      (parentRegion.type === "reference" ||
+        (parentRegion.type === "general" && !parentRegion.preserveGaps)) &&
       (previousSiblingDisposition.state === "removed" ||
         siblingDispositions.every((d) => d.state === "removed"))
     ) {

--- a/packages/test-app/babel-eval.js
+++ b/packages/test-app/babel-eval.js
@@ -1,10 +1,7 @@
 import { parseSync } from "https://local-disk/pkgs/npm/@babel/core/7.9.0/r2olrUApBIDwEqYQtp6rOMlGKH8=/src/index.js";
 import flatMap from "https://local-disk/pkgs/npm/lodash/4.17.19/NbTWX71F-LVzbYPD1xMbcjuRjD0=/flatMap.js";
 
-// TODO test a bundle built from CJS sources as well
-
 export function introspectESModule(code) {
-  debugger;
   let file = parseSync(code, { configFile: false });
   let body = file.program.body;
   let importDeclarations = body.filter((s) => s.type === "ImportDeclaration");


### PR DESCRIPTION
CS-188 add code region for reexport specifiers to be able to resolve consumption points for multiple bindings in a reexport of a package dep