### PR TITLE
CS-27 Service worker stability fixes

### DIFF
--- a/packages/builder-worker/package.json
+++ b/packages/builder-worker/package.json
@@ -52,6 +52,7 @@
     "fast-stable-stringify": "^1.0.0",
     "globals": "^13.5.0",
     "htmlparser2": "^4.1.0",
+    "idb-keyval": "^5.0.2",
     "imurmurhash": "^0.1.4",
     "json-stable-stringify": "^1.0.1",
     "lodash": "^4.17.19",

--- a/packages/builder-worker/src/event-bus.ts
+++ b/packages/builder-worker/src/event-bus.ts
@@ -79,7 +79,7 @@ export class EventBus {
     while (this.eventQueue.length > 0) {
       let item = this.eventQueue.shift()!;
       let { event, listener } = item;
-      let dispatched: () => void;
+      let dispatched: (value?: unknown) => void;
       let waitForDispatch = new Promise((res) => (dispatched = res));
       setTimeout(() => {
         listener(event);

--- a/packages/builder-worker/src/service-worker.ts
+++ b/packages/builder-worker/src/service-worker.ts
@@ -4,7 +4,7 @@ import {
   FileDaemonClientDriver,
 } from "../../file-daemon-client/src/index";
 import { FileSystem } from "./filesystem";
-import { addEventListener } from "./event-bus";
+import { addEventListener, dispatchEvent } from "./event-bus";
 import { debug, log, error, Logger } from "./logger";
 import { handleFile } from "./request-handlers/file-request-handler";
 import { handleClientRegister } from "./request-handlers/client-register-handler";
@@ -40,8 +40,9 @@ worker.addEventListener("install", () => {
   activating = new Promise<void>((res) => (activated = res));
   eventHandler = new ClientEventHandler();
   addEventListener(eventHandler.handleEvent.bind(eventHandler));
+  dispatchEvent({ uiManager: { type: "home" } });
 
-  log(`installing service worker`);
+  log(`Installing service worker`);
   websocketURL = new URL(defaultWebsocketURL);
 
   // force moving on to activation even if another service worker had control
@@ -87,8 +88,6 @@ async function activate() {
   );
   await fs.displayListing(log);
   activated();
-
-  // TODO tell the client to show the dashbaord
 }
 
 worker.addEventListener("fetch", (event: FetchEvent) => {

--- a/packages/builder-worker/src/service-worker.ts
+++ b/packages/builder-worker/src/service-worker.ts
@@ -98,11 +98,6 @@ worker.addEventListener("fetch", (event: FetchEvent) => {
   }
 
   event.respondWith(
-    //TODO I think there might be a race condition on the outside of this
-    //evaluated async block while a new version of the service working is being
-    //installed that results in a 404. I think we need to also consider how the
-    //old service worker can detect a new service worker is being installed and
-    //block until the new service worker can take over.
     (async () => {
       try {
         await activating;
@@ -130,10 +125,6 @@ worker.addEventListener("fetch", (event: FetchEvent) => {
         error(`An unhandled error occurred`, err);
       }
 
-      // instead of returning a 404, we should return some kind of response to
-      // signal to the UI to display a "Loading..." message. And then the
-      // service worker can send a "ready" signal to the client when install and
-      // activation is complete that will trigger the client to reload the page.
       return new Response("Not Found", { status: 404 });
     })()
   );

--- a/packages/builder-worker/src/service-worker.ts
+++ b/packages/builder-worker/src/service-worker.ts
@@ -82,8 +82,10 @@ async function activate() {
     new URL("https://local-disk/recipes/"),
     { bundle: { mountedPkgSource: new URL(localDiskPkgsHref) } },
     () => {
-      let dot = explainAsDot(buildManager.rebuilder!.explain());
-      debug(dot);
+      if (Logger.getInstance().logLevel === "debug") {
+        let dot = explainAsDot(buildManager.rebuilder!.explain());
+        debug(dot);
+      }
     }
   );
   await fs.displayListing(log);

--- a/packages/ui/app/components/project-selector.hbs
+++ b/packages/ui/app/components/project-selector.hbs
@@ -36,7 +36,7 @@
       <span class="bundle-strategy">Optimized bundles (modules combined into bundles)</span>
     </label>
   </div>
-  {{#if this.projects.start.isRunning}}
+  {{#if this.build.start.isRunning}}
   <div>Starting...</div>
   {{else}}
   <button onclick={{action startSelectedProject}} disabled={{if (eq this.selectedProjects.length 0) 'true'

--- a/packages/ui/app/components/project-selector.ts
+++ b/packages/ui/app/components/project-selector.ts
@@ -8,14 +8,14 @@ import { baseName } from "../helpers/base-name";
 import { task } from "ember-concurrency";
 
 export default class ProjectSelectorComponent extends Component {
-  defaultOrigin = location.origin;
   @service build!: BuildService;
   @tracked selectedProjects: [string, string][] = [];
-  @tracked selectedStrategy: string = "maximum";
+  @tracked selectedStrategy: string;
 
   constructor(owner: unknown, args: any) {
     super(owner, args);
     this.initialize.perform();
+    this.selectedStrategy = this.build.assigner;
   }
 
   initialize = task(function* (this: ProjectSelectorComponent) {

--- a/packages/ui/app/components/project-selector.ts
+++ b/packages/ui/app/components/project-selector.ts
@@ -2,14 +2,14 @@ import Component from "@glimmer/component";
 import { inject as service } from "@ember/service";
 import { tracked } from "@glimmer/tracking";
 import { action } from "@ember/object";
-import ProjectsService from "../services/projects";
+import BuildService from "../services/build";
 import { baseName } from "../helpers/base-name";
 // @ts-ignore
 import { task } from "ember-concurrency";
 
 export default class ProjectSelectorComponent extends Component {
   defaultOrigin = location.origin;
-  @service projects!: ProjectsService;
+  @service build!: BuildService;
   @tracked selectedProjects: [string, string][] = [];
   @tracked selectedStrategy: string = "maximum";
 
@@ -19,19 +19,19 @@ export default class ProjectSelectorComponent extends Component {
   }
 
   initialize = task(function* (this: ProjectSelectorComponent) {
-    yield this.projects.initialize.last;
+    yield this.build.initialize.last;
     this.selectedProjects = [...this.activeProjects!];
   }) as any;
 
   get availableProjects() {
-    return this.projects.listing?.availableProjects;
+    return this.build.listing?.availableProjects;
   }
   get activeProjects() {
-    return this.projects.listing?.activeProjects;
+    return this.build.listing?.activeProjects;
   }
 
   startSelectedProject() {
-    this.projects.start.perform(this.selectedProjects, this.selectedStrategy);
+    this.build.start.perform(this.selectedProjects, this.selectedStrategy);
   }
 
   @action

--- a/packages/ui/app/routes/application.ts
+++ b/packages/ui/app/routes/application.ts
@@ -1,11 +1,11 @@
 import Route from "@ember/routing/route";
 import { inject as service } from "@ember/service";
-import ProjectsService from "ui/services/projects";
+import BuildService from "ui/services/build";
 
 export default class CatalogJsUI extends Route {
-  @service projects!: ProjectsService;
+  @service build!: BuildService;
 
   async beforeModel() {
-    this.projects.initialize.perform();
+    this.build.initialize.perform();
   }
 }

--- a/packages/ui/app/services/build.ts
+++ b/packages/ui/app/services/build.ts
@@ -8,9 +8,9 @@ interface Projects {
   availableProjects: string[];
 }
 
-export default class ProjectsService extends Service {
+export default class BuildService extends Service {
   @tracked listing: Projects | undefined;
-  initialize = task(function* (this: ProjectsService) {
+  initialize = task(function* (this: BuildService) {
     if (!navigator.serviceWorker.controller) {
       navigator.serviceWorker.register("/service-worker.js", {
         scope: "/",
@@ -31,13 +31,13 @@ export default class ProjectsService extends Service {
   }).drop() as any;
 
   start = task(function* (
-    this: ProjectsService,
+    this: BuildService,
     projects: [string, string][],
     assigner: string
   ) {
     yield this.initialize.lastPerformed;
 
-    yield fetch("/config", {
+    yield fetch("/build", {
       method: "POST",
       body: JSON.stringify({ projects, assigner }),
     });

--- a/packages/ui/app/services/build.ts
+++ b/packages/ui/app/services/build.ts
@@ -10,7 +10,11 @@ interface Projects {
 
 export default class BuildService extends Service {
   @tracked listing: Projects | undefined;
+  @tracked assigner: string = "maximum";
   initialize = task(function* (this: BuildService) {
+    // we're using local storage here because we need to communicate this local
+    // state across different ember app instances
+    this.assigner = localStorage.getItem("assigner") ?? this.assigner;
     if (!navigator.serviceWorker.controller) {
       navigator.serviceWorker.register("/service-worker.js", {
         scope: "/",
@@ -35,6 +39,8 @@ export default class BuildService extends Service {
     projects: [string, string][],
     assigner: string
   ) {
+    localStorage.setItem("assigner", assigner);
+    this.assigner = assigner;
     yield this.initialize.lastPerformed;
 
     yield fetch("/build", {

--- a/packages/ui/app/services/logger.ts
+++ b/packages/ui/app/services/logger.ts
@@ -10,7 +10,7 @@ import {
 
 export default class LoggerService extends Service {
   @tracked messages: LogMessage[] = [];
-  @tracked logLevel: LogLevel = "debug";
+  @tracked logLevel: LogLevel = "info";
 
   startListening() {
     navigator.serviceWorker.addEventListener("message", (event) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8397,6 +8397,11 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
+idb-keyval@^5.0.2:
+  version "5.0.2"
+  resolved "https://registry.yarnpkg.com/idb-keyval/-/idb-keyval-5.0.2.tgz#243cf2b7db1bee2a8a41b78c14a18a85db0e1646"
+  integrity sha512-1DYjY/nX2U9pkTkwFoAmKcK1ZWmkNgO32Oon9tp/9+HURizxUQ4fZRxMJZs093SldP7q6dotVj03kIkiqOILyA==
+
 ieee754@^1.1.4:
   version "1.1.13"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
@@ -9882,10 +9887,20 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^0.2.1, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5, minimist@~0.0.1:
+minimist@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.2.1.tgz#827ba4e7593464e7c221e8c5bed930904ee2c455"
+  integrity sha512-GY8fANSrTMfBVfInqJAY41QkOM+upUTytK1jZ0c8+3HdHrJxBJ3rF5i9moClXTE8uUSnUo8cAsCoxDXvSY4DHg==
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
 
 minipass@^2.2.0:
   version "2.9.0"


### PR DESCRIPTION
The primary issue is that the dom client gets out of sync with the service worker. For instance, the service worker will be updated, uninstalled and reinstalled, in which case the build is no longer available. however, the DOM client is still displaying the last built project from before the service worker was updated. When the service worker is updated, we need to reset the DOM client back to the dashboard page.

I moved our window client ID's, which the service worker needs in order to communicate with the window , into IndexedDB so that all service worker instances have the ability to communicate with the current window client (service workers aren't allowed talk to local storage).  Previously the window client ID only lived inside of the current service worker context (so a newly installed service worker would not know how to talk to the visible window in the case of a service worker update). I also made an update so that the on the install event, the service worker triggers an event (using our now globally available window client ID's) for the UI to return to the dashboard. This way we stay in sync, so that when there is no longer a build available, because a new service worker has been installed, the window will now reflect that--and not be in this weird state where you see the window artifacts of a service worker that no longer exists (which is when the service worker starts feeling broken).

So now when you make a change to the service worker code base, webpack will recompile. webpack dev server also does a page reload which triggers the new version of the service worker to be installed. There is a couple second delay until the browser actually begins the installation process, during this delay page reloads work just fine since the old service worker is still happily serving content via the fetch service worker API. as soon as the browser starts the installation of the new service worker, the window switches to the dashboard view. page reloads during this time are blocked until the installation and activation promises is resolved.

Any build failures are also visible in the logger window (as well as the console), and the logging failures don't leave the service worker in an unrecoverable state. you can either fix the source code and the service worker will pick up the change and re-build, or you can click on the "Manage Projects" button to go back to the dashboard and configure your project differently.

Note this also fixes #CS-198