### PR TITLE
Fixes CS-309 does not serve untranspiled assets when initial build has failed

### DIFF
--- a/packages/builder-worker/src/builder.ts
+++ b/packages/builder-worker/src/builder.ts
@@ -476,6 +476,7 @@ type RebuilderState =
     };
 
 export class Rebuilder<Input> {
+  private successfulBuildOccurred = false;
   private runner: BuildRunner<Input>;
   private state: RebuilderState = {
     name: "created",
@@ -515,6 +516,12 @@ export class Rebuilder<Input> {
       whenIdle,
       hasAlreadyBuilt
     );
+  }
+
+  // this intent here is just to indicate that at least one build has been
+  // successful
+  get hadSuccessfulBuild() {
+    return this.successfulBuildOccurred;
   }
 
   get status():
@@ -581,6 +588,7 @@ export class Rebuilder<Input> {
             if (this.state.name === "working" && this.hasAlreadyBuilt) {
               dispatchEvent({ reload: true } as Event);
             }
+            this.successfulBuildOccurred = true;
             this.hasAlreadyBuilt = true;
             this.setState({ name: "idle", lastBuildSucceeded: true });
           } catch (err) {

--- a/packages/builder-worker/src/request-handlers/file-request-handler.ts
+++ b/packages/builder-worker/src/request-handlers/file-request-handler.ts
@@ -37,7 +37,7 @@ export function handleFile(fs: FileSystem, buildManager: BuildManager) {
 
     // if the projects have not been built yet, then serve the UI
     if (
-      !buildManager.rebuilder &&
+      (!buildManager.rebuilder || !buildManager.rebuilder.hadSuccessfulBuild) &&
       !requestURL.href.startsWith(`${originURL}catalogjs/ui/`)
     ) {
       requestURL = new URL(
@@ -52,7 +52,7 @@ export function handleFile(fs: FileSystem, buildManager: BuildManager) {
     // we serve each project's input files as a fallback to their output
     // files, which lets you not worry about assets that are unchanged by the
     // build.
-    if (response.status === 404 && buildManager.rebuilder) {
+    if (response.status === 404 && buildManager.rebuilder?.hadSuccessfulBuild) {
       // find the closest matching project output to our file URL, which will be the output
       // that has the longest URL (in this case one project has an output URL that
       // is the parent of another project)


### PR DESCRIPTION
The issue here is critically the first build. Until there is a first successful build, we will not allow the service worker to serve assets from the project input folder (which is how successful builds handle requests for assets that do no require transpilation). As well as, reloads of the page will continue to render the dashboard. After the build has passed the first time, then future unsuccessful builds will just render the last successful build.